### PR TITLE
Add Collector data retrieval functionality

### DIFF
--- a/app/src/main/java/com/tsdc/vinilos/data/mappers/CollectorMapper.kt
+++ b/app/src/main/java/com/tsdc/vinilos/data/mappers/CollectorMapper.kt
@@ -1,0 +1,11 @@
+package com.tsdc.vinilos.data.mappers
+
+import com.tsdc.vinilos.data.remote.dto.CollectorDto
+import com.tsdc.vinilos.domain.models.Collector
+
+fun CollectorDto.toDomain(): Collector = Collector(
+    id = id,
+    name = name,
+    telephone = telephone,
+    email = email
+)

--- a/app/src/main/java/com/tsdc/vinilos/data/remote/dto/CollectorDto.kt
+++ b/app/src/main/java/com/tsdc/vinilos/data/remote/dto/CollectorDto.kt
@@ -1,0 +1,8 @@
+package com.tsdc.vinilos.data.remote.dto
+
+data class CollectorDto(
+    val id: Int,
+    val name: String,
+    val telephone: String,
+    val email: String
+)

--- a/app/src/main/java/com/tsdc/vinilos/data/remote/network/ServiceAdapter.kt
+++ b/app/src/main/java/com/tsdc/vinilos/data/remote/network/ServiceAdapter.kt
@@ -2,6 +2,7 @@ package com.tsdc.vinilos.data.remote.network
 import com.tsdc.vinilos.data.mappers.toDomain
 import com.tsdc.vinilos.domain.models.Album
 import com.tsdc.vinilos.domain.models.Artist
+import com.tsdc.vinilos.domain.models.Collector
 
 class ServiceAdapter(private val apiService: VinilosApiService) {
     suspend fun fetchAlbums(): List<Album> = 
@@ -13,4 +14,7 @@ class ServiceAdapter(private val apiService: VinilosApiService) {
 
     suspend fun fetchArtists(): List<Artist> =
         apiService.getArtists().map { it.toDomain() }
+
+    suspend fun fetchCollectors(): List<Collector> =
+        apiService.getCollectors().map { it.toDomain() }
 }

--- a/app/src/main/java/com/tsdc/vinilos/data/remote/network/VinilosApiService.kt
+++ b/app/src/main/java/com/tsdc/vinilos/data/remote/network/VinilosApiService.kt
@@ -1,6 +1,7 @@
 package com.tsdc.vinilos.data.remote.network
 import com.tsdc.vinilos.data.remote.dto.AlbumDto
 import com.tsdc.vinilos.data.remote.dto.ArtistDto
+import com.tsdc.vinilos.data.remote.dto.CollectorDto
 import retrofit2.http.GET
 import retrofit2.http.Path
 import com.tsdc.vinilos.domain.models.Album
@@ -16,4 +17,7 @@ interface VinilosApiService {
 
     @GET("musicians")
     suspend fun getArtists(): List<ArtistDto>
+
+    @GET("collectors")
+    suspend fun getCollectors(): List<CollectorDto>
 }

--- a/app/src/main/java/com/tsdc/vinilos/data/repositories/CollectorRepository.kt
+++ b/app/src/main/java/com/tsdc/vinilos/data/repositories/CollectorRepository.kt
@@ -1,0 +1,11 @@
+package com.tsdc.vinilos.data.repositories
+
+import com.tsdc.vinilos.data.remote.network.ServiceAdapter
+import com.tsdc.vinilos.domain.models.Collector
+import com.tsdc.vinilos.domain.repositories.CollectorRepository as CollectorRepositoryInterface
+
+class CollectorRepository(
+    private val serviceAdapter: ServiceAdapter
+) : CollectorRepositoryInterface {
+    override suspend fun getCollectors(): List<Collector> = serviceAdapter.fetchCollectors()
+}

--- a/app/src/main/java/com/tsdc/vinilos/di/AppModule.kt
+++ b/app/src/main/java/com/tsdc/vinilos/di/AppModule.kt
@@ -4,11 +4,14 @@ import com.tsdc.vinilos.data.remote.network.ServiceAdapter
 import com.tsdc.vinilos.data.remote.network.VinilosApiService
 import com.tsdc.vinilos.data.repositories.ArtistRepository as ArtistRepositoryImpl
 import com.tsdc.vinilos.data.repositories.AlbumRepository as AlbumRepositoryImpl
+import com.tsdc.vinilos.data.repositories.CollectorRepository as CollectorRepositoryImpl
 import com.tsdc.vinilos.domain.repositories.AlbumRepository
 import com.tsdc.vinilos.domain.repositories.ArtistRepository
+import com.tsdc.vinilos.domain.repositories.CollectorRepository
 import com.tsdc.vinilos.domain.usecases.GetAlbumByIdUseCase
 import com.tsdc.vinilos.domain.usecases.GetAlbumsUseCase
 import com.tsdc.vinilos.domain.usecases.GetArtistsUseCase
+import com.tsdc.vinilos.domain.usecases.GetCollectorsUseCase
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -49,5 +52,13 @@ object AppModule {
 
     val getArtistsUseCase: GetArtistsUseCase by lazy {
         GetArtistsUseCase(artistRepository)
+    }
+
+    val collectorRepository: CollectorRepository by lazy {
+        CollectorRepositoryImpl(serviceAdapter)
+    }
+
+    val getCollectorsUseCase: GetCollectorsUseCase by lazy {
+        GetCollectorsUseCase(collectorRepository)
     }
 }

--- a/app/src/main/java/com/tsdc/vinilos/domain/models/Collector.kt
+++ b/app/src/main/java/com/tsdc/vinilos/domain/models/Collector.kt
@@ -1,0 +1,8 @@
+package com.tsdc.vinilos.domain.models
+
+data class Collector(
+    val id: Int,
+    val name: String,
+    val telephone: String,
+    val email: String
+)

--- a/app/src/main/java/com/tsdc/vinilos/domain/repositories/CollectorRepository.kt
+++ b/app/src/main/java/com/tsdc/vinilos/domain/repositories/CollectorRepository.kt
@@ -1,0 +1,7 @@
+package com.tsdc.vinilos.domain.repositories
+
+import com.tsdc.vinilos.domain.models.Collector
+
+interface CollectorRepository {
+    suspend fun getCollectors(): List<Collector>
+}

--- a/app/src/main/java/com/tsdc/vinilos/domain/usecases/GetCollectorsUseCase.kt
+++ b/app/src/main/java/com/tsdc/vinilos/domain/usecases/GetCollectorsUseCase.kt
@@ -1,0 +1,10 @@
+package com.tsdc.vinilos.domain.usecases
+
+import com.tsdc.vinilos.domain.models.Collector
+import com.tsdc.vinilos.domain.repositories.CollectorRepository
+
+class GetCollectorsUseCase(private val repository: CollectorRepository) {
+    suspend operator fun invoke(): List<Collector> {
+        return repository.getCollectors()
+    }
+}

--- a/app/src/test/java/com/tsdc/vinilos/data/repositories/AlbumRepositoryTest.kt
+++ b/app/src/test/java/com/tsdc/vinilos/data/repositories/AlbumRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.tsdc.vinilos.data.repositories
 
 import com.tsdc.vinilos.data.remote.dto.AlbumDto
 import com.tsdc.vinilos.data.remote.dto.ArtistDto
+import com.tsdc.vinilos.data.remote.dto.CollectorDto
 import com.tsdc.vinilos.data.remote.network.ServiceAdapter
 import com.tsdc.vinilos.data.remote.network.VinilosApiService
 import com.tsdc.vinilos.domain.models.Album
@@ -49,4 +50,6 @@ private class FakeVinilosApiService(
     }
 
     override suspend fun getArtists(): List<ArtistDto> = emptyList()
+
+    override suspend fun getCollectors(): List<CollectorDto> = emptyList()
 }

--- a/app/src/test/java/com/tsdc/vinilos/data/repositories/ArtistRepositoryTest.kt
+++ b/app/src/test/java/com/tsdc/vinilos/data/repositories/ArtistRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.tsdc.vinilos.data.repositories
 
 import com.tsdc.vinilos.data.remote.dto.AlbumDto
 import com.tsdc.vinilos.data.remote.dto.ArtistDto
+import com.tsdc.vinilos.data.remote.dto.CollectorDto
 import com.tsdc.vinilos.data.remote.network.ServiceAdapter
 import com.tsdc.vinilos.data.remote.network.VinilosApiService
 import com.tsdc.vinilos.domain.models.Album
@@ -65,4 +66,6 @@ private class FakeVinilosApiServiceForArtists(
         wasGetArtistsCalled = true
         return artistsToReturn
     }
+
+    override suspend fun getCollectors(): List<CollectorDto> = emptyList()
 }

--- a/app/src/test/java/com/tsdc/vinilos/data/repositories/CollectorRepositoryTest.kt
+++ b/app/src/test/java/com/tsdc/vinilos/data/repositories/CollectorRepositoryTest.kt
@@ -1,0 +1,57 @@
+package com.tsdc.vinilos.data.repositories
+
+import com.tsdc.vinilos.data.remote.dto.AlbumDto
+import com.tsdc.vinilos.data.remote.dto.ArtistDto
+import com.tsdc.vinilos.data.remote.dto.CollectorDto
+import com.tsdc.vinilos.data.remote.network.ServiceAdapter
+import com.tsdc.vinilos.data.remote.network.VinilosApiService
+import com.tsdc.vinilos.domain.models.Album
+import com.tsdc.vinilos.domain.models.Collector
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CollectorRepositoryTest {
+
+    @Test
+    fun getCollectors_returnsMappedListFromApi() = runBlocking {
+        val dtos = listOf(
+            CollectorDto(301, "Ana", "3001112233", "ana@mail.com"),
+            CollectorDto(302, "Luis", "3004445566", "luis@mail.com")
+        )
+        val expected = listOf(
+            Collector(301, "Ana", "3001112233", "ana@mail.com"),
+            Collector(302, "Luis", "3004445566", "luis@mail.com")
+        )
+
+        val fakeApi = FakeVinilosApiServiceForCollectors(dtos)
+        val repository = CollectorRepository(ServiceAdapter(fakeApi))
+
+        val result = repository.getCollectors()
+
+        assertTrue(fakeApi.wasGetCollectorsCalled)
+        assertEquals(expected, result)
+    }
+}
+
+private class FakeVinilosApiServiceForCollectors(
+    private val collectorsToReturn: List<CollectorDto>
+) : VinilosApiService {
+
+    var wasGetCollectorsCalled: Boolean = false
+        private set
+
+    override suspend fun getAlbums(): List<AlbumDto> = emptyList()
+
+    override suspend fun getAlbumById(albumId: Int): Album {
+        error("no usado en test de coleccionistas")
+    }
+
+    override suspend fun getArtists(): List<ArtistDto> = emptyList()
+
+    override suspend fun getCollectors(): List<CollectorDto> {
+        wasGetCollectorsCalled = true
+        return collectorsToReturn
+    }
+}


### PR DESCRIPTION
- Implemented fetchCollectors method in ServiceAdapter to retrieve collectors from the API.
- Updated VinilosApiService to include a new endpoint for fetching collectors.
- Added CollectorRepository and GetCollectorsUseCase in AppModule for dependency injection.
- Enhanced test classes to support collector data retrieval with a fake API service.