### PR TITLE
Add UI tests for Artist and Collector lists

### DIFF
--- a/app/src/androidTest/java/com/tsdc/vinilos/ArtistListComposeTest.kt
+++ b/app/src/androidTest/java/com/tsdc/vinilos/ArtistListComposeTest.kt
@@ -3,20 +3,19 @@ package com.tsdc.vinilos
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.tsdc.vinilos.domain.usecases.GetAlbumsUseCase
 import com.tsdc.vinilos.domain.usecases.GetArtistsUseCase
 import com.tsdc.vinilos.domain.usecases.GetCollectorsUseCase
 import com.tsdc.vinilos.ui.screens.HomeScreen
+import com.tsdc.vinilos.ui.shared.constants.UiTestTags
 import com.tsdc.vinilos.ui.shared.theme.VinilosTheme
 import com.tsdc.vinilos.ui.viewmodels.AlbumViewModel
 import com.tsdc.vinilos.ui.viewmodels.ArtistViewModel
@@ -26,12 +25,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class AlbumScreenEspressoTest {
+class ArtistListComposeTest {
 
     @get:Rule
     val composeRule = createAndroidComposeRule<ComponentActivity>()
 
-    private fun launchHomeWithFakeCatalog() {
+    private fun launchHomeWithFakes() {
         composeRule.setContent {
             VinilosTheme {
                 val albumViewModel = remember {
@@ -54,55 +53,46 @@ class AlbumScreenEspressoTest {
         }
     }
 
-    private fun navigateToAlbums() {
-        composeRule.onNodeWithTag("nav_albums").performClick()
+    private fun navigateToArtists() {
+        composeRule.onNodeWithTag("nav_artists").performClick()
     }
 
-    private fun assertAlbumTitleVisible(title: String, timeoutMs: Long = 10_000L) {
+    private fun waitForArtistItems(timeoutMs: Long = 10_000L) {
         composeRule.waitUntil(timeoutMs) {
-            composeRule.onAllNodesWithText(title).fetchSemanticsNodes().isNotEmpty()
-        }
-        composeRule.onAllNodesWithText(title).onFirst().assertIsDisplayed()
-    }
-
-    private fun assertAlbumTitleAbsent(title: String, timeoutMs: Long = 10_000L) {
-        composeRule.waitUntil(timeoutMs) {
-            composeRule.onAllNodesWithText(title).fetchSemanticsNodes().isEmpty()
+            composeRule
+                .onAllNodesWithTag(UiTestTags.ARTIST_LIST_ITEM, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
         }
     }
 
     @Test
-    fun navigateToAlbums_showsLibraryHeader() {
-        launchHomeWithFakeCatalog()
-        navigateToAlbums()
-        composeRule.onNodeWithText("YOUR LIBRARY").assertIsDisplayed()
-        composeRule.onNodeWithText("The Analog Curator").assertIsDisplayed()
+    fun artistsTab_showsSectionAndCatalogNames() {
+        launchHomeWithFakes()
+        navigateToArtists()
+
+        composeRule.onNodeWithText("Artists").assertIsDisplayed()
+        composeRule.onNodeWithText("FEATURED ARTISTS").assertIsDisplayed()
+
+        waitForArtistItems()
+        composeRule.onNodeWithText("Rubén Blades Bellido de Luna", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Queen").assertIsDisplayed()
     }
 
     @Test
-    fun albumsList_displaysCatalogTitles() {
-        launchHomeWithFakeCatalog()
-        navigateToAlbums()
+    fun artistsSearch_filtersByName() {
+        launchHomeWithFakes()
+        navigateToArtists()
+        waitForArtistItems()
 
-        assertAlbumTitleVisible("Buscando América")
-        assertAlbumTitleVisible("Poeta del pueblo")
-        assertAlbumTitleVisible("A Night at the Opera")
+        composeRule.onNodeWithText("Queen").assertIsDisplayed()
 
-        composeRule.onNodeWithTag("album_list").performScrollToNode(hasText("A Day at the Races"))
-        assertAlbumTitleVisible("A Day at the Races")
-    }
-
-    @Test
-    fun searchFiltersAlbumsByTitle() {
-        launchHomeWithFakeCatalog()
-        navigateToAlbums()
-        assertAlbumTitleVisible("Buscando América")
-        assertAlbumTitleVisible("Poeta del pueblo")
-
-        composeRule.onNodeWithTag("album_search_field").performTextReplacement("Poeta")
+        composeRule.onNodeWithTag(UiTestTags.ARTIST_SEARCH_FIELD).performTextReplacement("Rubén")
         composeRule.waitForIdle()
 
-        assertAlbumTitleVisible("Poeta del pueblo")
-        assertAlbumTitleAbsent("Buscando América")
+        composeRule.onNodeWithText("Rubén Blades Bellido de Luna", substring = true).assertIsDisplayed()
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithText("Queen").fetchSemanticsNodes().isEmpty()
+        }
     }
 }

--- a/app/src/androidTest/java/com/tsdc/vinilos/CollectorListComposeTest.kt
+++ b/app/src/androidTest/java/com/tsdc/vinilos/CollectorListComposeTest.kt
@@ -3,20 +3,19 @@ package com.tsdc.vinilos
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.tsdc.vinilos.domain.usecases.GetAlbumsUseCase
 import com.tsdc.vinilos.domain.usecases.GetArtistsUseCase
 import com.tsdc.vinilos.domain.usecases.GetCollectorsUseCase
 import com.tsdc.vinilos.ui.screens.HomeScreen
+import com.tsdc.vinilos.ui.shared.constants.UiTestTags
 import com.tsdc.vinilos.ui.shared.theme.VinilosTheme
 import com.tsdc.vinilos.ui.viewmodels.AlbumViewModel
 import com.tsdc.vinilos.ui.viewmodels.ArtistViewModel
@@ -26,12 +25,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class AlbumScreenEspressoTest {
+class CollectorListComposeTest {
 
     @get:Rule
     val composeRule = createAndroidComposeRule<ComponentActivity>()
 
-    private fun launchHomeWithFakeCatalog() {
+    private fun launchHomeWithFakes() {
         composeRule.setContent {
             VinilosTheme {
                 val albumViewModel = remember {
@@ -54,55 +53,45 @@ class AlbumScreenEspressoTest {
         }
     }
 
-    private fun navigateToAlbums() {
-        composeRule.onNodeWithTag("nav_albums").performClick()
+    private fun navigateToCollectors() {
+        composeRule.onNodeWithTag("nav_collectors").performClick()
     }
 
-    private fun assertAlbumTitleVisible(title: String, timeoutMs: Long = 10_000L) {
+    private fun waitForCollectorItems(timeoutMs: Long = 10_000L) {
         composeRule.waitUntil(timeoutMs) {
-            composeRule.onAllNodesWithText(title).fetchSemanticsNodes().isNotEmpty()
-        }
-        composeRule.onAllNodesWithText(title).onFirst().assertIsDisplayed()
-    }
-
-    private fun assertAlbumTitleAbsent(title: String, timeoutMs: Long = 10_000L) {
-        composeRule.waitUntil(timeoutMs) {
-            composeRule.onAllNodesWithText(title).fetchSemanticsNodes().isEmpty()
+            composeRule
+                .onAllNodesWithTag(UiTestTags.COLLECTOR_LIST_ITEM, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
         }
     }
 
     @Test
-    fun navigateToAlbums_showsLibraryHeader() {
-        launchHomeWithFakeCatalog()
-        navigateToAlbums()
-        composeRule.onNodeWithText("YOUR LIBRARY").assertIsDisplayed()
-        composeRule.onNodeWithText("The Analog Curator").assertIsDisplayed()
+    fun collectorsTab_showsSectionsAndCatalogNames() {
+        launchHomeWithFakes()
+        navigateToCollectors()
+
+        composeRule.onNodeWithText("Collectors").assertIsDisplayed()
+        composeRule.onNodeWithText("COMMUNITY").assertIsDisplayed()
+        composeRule.onNodeWithText("CURATORS & ENTHUSIASTS").assertIsDisplayed()
+
+        waitForCollectorItems()
+        composeRule.onNodeWithText("Manolo Bellon").assertIsDisplayed()
+        composeRule.onNodeWithText("Jaime Monsalve").assertIsDisplayed()
     }
 
     @Test
-    fun albumsList_displaysCatalogTitles() {
-        launchHomeWithFakeCatalog()
-        navigateToAlbums()
+    fun collectorsSearch_filtersByEmail() {
+        launchHomeWithFakes()
+        navigateToCollectors()
+        waitForCollectorItems()
 
-        assertAlbumTitleVisible("Buscando América")
-        assertAlbumTitleVisible("Poeta del pueblo")
-        assertAlbumTitleVisible("A Night at the Opera")
-
-        composeRule.onNodeWithTag("album_list").performScrollToNode(hasText("A Day at the Races"))
-        assertAlbumTitleVisible("A Day at the Races")
-    }
-
-    @Test
-    fun searchFiltersAlbumsByTitle() {
-        launchHomeWithFakeCatalog()
-        navigateToAlbums()
-        assertAlbumTitleVisible("Buscando América")
-        assertAlbumTitleVisible("Poeta del pueblo")
-
-        composeRule.onNodeWithTag("album_search_field").performTextReplacement("Poeta")
+        composeRule.onNodeWithTag(UiTestTags.COLLECTOR_SEARCH_FIELD).performTextReplacement("jmonsalve")
         composeRule.waitForIdle()
 
-        assertAlbumTitleVisible("Poeta del pueblo")
-        assertAlbumTitleAbsent("Buscando América")
+        composeRule.onNodeWithText("Jaime Monsalve").assertIsDisplayed()
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithText("Manolo Bellon").fetchSemanticsNodes().isEmpty()
+        }
     }
 }

--- a/app/src/androidTest/java/com/tsdc/vinilos/FakeArtistRepository.kt
+++ b/app/src/androidTest/java/com/tsdc/vinilos/FakeArtistRepository.kt
@@ -1,0 +1,42 @@
+package com.tsdc.vinilos
+
+import com.tsdc.vinilos.domain.models.Artist
+import com.tsdc.vinilos.domain.repositories.ArtistRepository
+import java.util.Calendar
+import java.util.Date
+
+private fun date(year: Int, month: Int, day: Int): Date =
+    Calendar.getInstance().apply {
+        set(Calendar.YEAR, year)
+        set(Calendar.MONTH, month - 1)
+        set(Calendar.DAY_OF_MONTH, day)
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.time
+
+
+private val sampleArtists = listOf(
+    Artist(
+        id = 100,
+        name = "Rubén Blades Bellido de Luna",
+        image = "",
+        description = "Es un cantante, compositor y músico panameño.",
+        birthDate = date(1948, 7, 16)
+    ),
+    Artist(
+        id = 101,
+        name = "Queen",
+        image = "",
+        description = "Banda británica de rock formada en Londres.",
+        birthDate = date(1970, 1, 1)
+    )
+)
+
+class FakeArtistRepository(
+    private val artists: List<Artist> = sampleArtists
+) : ArtistRepository {
+
+    override suspend fun getArtists(): List<Artist> = artists
+}

--- a/app/src/androidTest/java/com/tsdc/vinilos/FakeCollectorRepository.kt
+++ b/app/src/androidTest/java/com/tsdc/vinilos/FakeCollectorRepository.kt
@@ -1,0 +1,26 @@
+package com.tsdc.vinilos
+
+import com.tsdc.vinilos.domain.models.Collector
+import com.tsdc.vinilos.domain.repositories.CollectorRepository
+
+private val sampleCollectors = listOf(
+    Collector(
+        id = 100,
+        name = "Manolo Bellon",
+        telephone = "3502457896",
+        email = "manollo@caracol.com.co"
+    ),
+    Collector(
+        id = 101,
+        name = "Jaime Monsalve",
+        telephone = "3012357936",
+        email = "jmonsalve@rtvc.com.co"
+    )
+)
+
+class FakeCollectorRepository(
+    private val collectors: List<Collector> = sampleCollectors
+) : CollectorRepository {
+
+    override suspend fun getCollectors(): List<Collector> = collectors
+}

--- a/app/src/main/java/com/tsdc/vinilos/ui/screens/ArtistScreen.kt
+++ b/app/src/main/java/com/tsdc/vinilos/ui/screens/ArtistScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -52,10 +53,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tsdc.vinilos.di.AppModule
+import com.tsdc.vinilos.ui.shared.constants.UiTestTags
 import com.tsdc.vinilos.ui.viewmodels.ArtistViewModel
 import com.tsdc.vinilos.ui.viewmodels.CollectorViewModel
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
@@ -133,7 +133,8 @@ fun ArtistScreen(viewModel: ArtistViewModel) {
             onValueChange = { searchQuery = it },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 10.dp),
+                .padding(horizontal = 20.dp, vertical = 10.dp)
+                .testTag(UiTestTags.ARTIST_SEARCH_FIELD),
             placeholder = {
                 Text("Search artists...", color = Color(0xFFA0A7B5), fontSize = 15.sp)
             },

--- a/app/src/main/java/com/tsdc/vinilos/ui/screens/CollectorScreen.kt
+++ b/app/src/main/java/com/tsdc/vinilos/ui/screens/CollectorScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -51,6 +52,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tsdc.vinilos.di.AppModule
+import com.tsdc.vinilos.ui.shared.constants.UiTestTags
 import com.tsdc.vinilos.ui.viewmodels.CollectorViewModel
 
 @Preview(showBackground = true, showSystemUi = true)
@@ -129,7 +131,8 @@ fun CollectorScreen(viewModel: CollectorViewModel) {
             onValueChange = { searchQuery = it },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 10.dp),
+                .padding(horizontal = 20.dp, vertical = 10.dp)
+                .testTag(UiTestTags.COLLECTOR_SEARCH_FIELD),
             placeholder = {
                 Text("Search collectors...", color = Color(0xFFA0A7B5), fontSize = 15.sp)
             },

--- a/app/src/main/java/com/tsdc/vinilos/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/tsdc/vinilos/ui/screens/HomeScreen.kt
@@ -85,8 +85,15 @@ fun HomeScreen(
         bottomBar = {
             NavigationBar(containerColor = Color.White) {
                 navLabels.forEachIndexed { index, label ->
+                    val navModifier = when (index) {
+                        0 -> Modifier.testTag("nav_home")
+                        1 -> Modifier.testTag("nav_albums")
+                        2 -> Modifier.testTag("nav_artists")
+                        3 -> Modifier.testTag("nav_collectors")
+                        else -> Modifier
+                    }
                     NavigationBarItem(
-                        modifier = if (index == 1) Modifier.testTag("nav_albums") else Modifier,
+                        modifier = navModifier,
                         selected = selectedIndex == index,
                         onClick = { selectedIndex = index },
                         icon = {

--- a/app/src/main/java/com/tsdc/vinilos/ui/shared/constants/UiTestTags.kt
+++ b/app/src/main/java/com/tsdc/vinilos/ui/shared/constants/UiTestTags.kt
@@ -8,4 +8,6 @@ object UiTestTags {
     const val ALBUM_DETAIL_ROOT = "album_detail_root"
     const val ARTIST_LIST_ITEM = "artist_list_item"
     const val COLLECTOR_LIST_ITEM = "collector_list_item"
+    const val ARTIST_SEARCH_FIELD = "artist_search_field"
+    const val COLLECTOR_SEARCH_FIELD = "collector_search_field"
 }


### PR DESCRIPTION
- Implemented `ArtistListComposeTest` to verify the display of artist sections and search functionality.
- Created `CollectorListComposeTest` to ensure collector sections and email filtering work as expected.
- Added `FakeArtistRepository` and `FakeCollectorRepository` to provide mock data for testing.