### PR TITLE
Se hacen cambios para ejecutar pruebas de reconocimiento

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,67 @@ cd <NOMBRE_DEL_PROYECTO>
 
 ## 2. Configurar Java para Android
 
-Si Gradle falla por problemas de Java, usar temporalmente el JBR de Android Studio:
+Este proyecto no fija `org.gradle.java.home` en el repositorio para evitar rutas locales que rompan en otros equipos.
+
+Cada desarrollador debe configurar su JDK de Gradle en su maquina (recomendado JDK 17 o 21).
+
+### Opcion A (recomendada): Android Studio
+
+```txt
+File > Settings > Build, Execution, Deployment > Build Tools > Gradle > Gradle JDK
+```
+
+En `Gradle JDK`, seleccionar una de estas opciones:
+
+```txt
+1) Embedded JDK (recomendado)
+2) JDK 21 (si lo tienes instalado)
+3) JDK 17 (si lo tienes instalado)
+```
+
+No usar JDK 25 para este proyecto.
+
+Luego aplicar cambios y sincronizar:
+
+```txt
+Apply > OK > Sync Project with Gradle Files
+```
+
+### Opcion B: gradle.properties local del usuario
+
+Crear o editar:
+
+```txt
+C:/Users/<TU_USUARIO>/.gradle/gradle.properties
+```
+
+Agregar:
+
+```properties
+org.gradle.java.home=C:/Program Files/Android/Android Studio/jbr
+```
+
+Comandos sugeridos (PowerShell, Windows):
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE/.gradle" | Out-Null
+@"
+org.gradle.java.home=C:/Program Files/Android/Android Studio/jbr
+"@ | Set-Content -Path "$env:USERPROFILE/.gradle/gradle.properties"
+Get-Content "$env:USERPROFILE/.gradle/gradle.properties"
+```
+
+Comandos sugeridos (Git Bash, Windows):
+
+```bash
+mkdir -p ~/.gradle
+cat > ~/.gradle/gradle.properties << 'EOF'
+org.gradle.java.home=C:/Program Files/Android/Android Studio/jbr
+EOF
+cat ~/.gradle/gradle.properties
+```
+
+### Opcion C: solo para la terminal actual (temporal)
 
 ```powershell
 $env:JAVA_HOME="C:\Program Files\Android\Android Studio\jbr"
@@ -37,16 +97,27 @@ java -version
 
 Esta configuración es temporal y solo afecta la terminal actual.
 
-También se puede configurar desde Android Studio:
+Comandos sugeridos (Git Bash):
 
-```txt
-File > Settings > Build, Execution, Deployment > Build Tools > Gradle > Gradle JDK
+```bash
+export JAVA_HOME="/c/Program Files/Android/Android Studio/jbr"
+export PATH="$JAVA_HOME/bin:$PATH"
+java -version
 ```
 
-Seleccionar:
+Verificar con:
 
-```txt
-Embedded JDK / jbr
+```bash
+./gradlew -version
+```
+
+La JVM debe mostrar Java 17 o 21.
+
+Validaciones utiles:
+
+```bash
+java -version
+./gradlew -version
 ```
 
 ---
@@ -123,7 +194,39 @@ No usar `localhost` dentro de la app Android cuando se ejecuta en emulador, porq
 
 ---
 
-## 5. Ejecutar la app Android
+## 5. Flavors y variantes de build
+
+Este proyecto usa flavors para definir entorno y origen de datos.
+
+### Flavors disponibles
+
+- `local`: usa `BASE_URL = http://10.0.2.2:3000/` y `USE_FAKE_DATA = false`
+- `prod`: usa backend productivo y `USE_FAKE_DATA = false`
+- `robo`: usa `USE_FAKE_DATA = true` (repositorios fake, sin consumo de backend)
+
+### Variantes resultantes
+
+- `localDebug` / `localRelease`
+- `prodDebug` / `prodRelease`
+- `roboDebug` / `roboRelease`
+
+Comandos recomendados de ensamblado:
+
+```bash
+./gradlew app:assembleLocalDebug
+./gradlew app:assembleProdDebug
+./gradlew app:assembleRoboDebug
+```
+
+APK esperado para Robo Test:
+
+```txt
+app/build/outputs/apk/robo/debug/app-robo-debug.apk
+```
+
+---
+
+## 6. Ejecutar la app Android
 
 Abrir el proyecto Android en Android Studio:
 
@@ -145,17 +248,21 @@ Debe aparecer algo como:
 emulator-5554    device
 ```
 
-Instalar la app desde terminal:
+Instalar la variante que quieras probar desde terminal:
 
 ```powershell
-.\gradlew.bat installDebug
+.\gradlew.bat app:installLocalDebug
+.\gradlew.bat app:installProdDebug
+.\gradlew.bat app:installRoboDebug
 ```
 
 O ejecutarla desde Android Studio usando el botón verde Run.
 
+Importante: en Android Studio selecciona la variante correcta en `Build Variants` antes de ejecutar.
+
 ---
 
-## 6. Probar la conexión desde el emulador
+## 7. Probar la conexión desde el emulador
 
 Abrir Chrome en el emulador y probar:
 
@@ -165,9 +272,11 @@ http://10.0.2.2:3000/albums
 
 Si aparece el JSON de álbumes, la app Android puede comunicarse con el backend.
 
+Nota: esta validación aplica para `local` y `prod`. En `robo` la app usa datos fake y no requiere backend.
+
 ---
 
-## 7. Ejecutar pruebas unitarias Android
+## 8. Ejecutar pruebas unitarias Android
 
 Las pruebas unitarias locales están en:
 
@@ -178,12 +287,14 @@ app/src/test/java
 Para ejecutarlas:
 
 ```powershell
-.\gradlew.bat testDebugUnitTest
+.\gradlew.bat testLocalDebugUnitTest
+.\gradlew.bat testProdDebugUnitTest
+.\gradlew.bat testRoboDebugUnitTest
 ```
 
 ---
 
-## 8. Ejecutar pruebas instrumentadas / Espresso
+## 9. Ejecutar pruebas instrumentadas / Espresso
 
 Las pruebas Espresso están en:
 
@@ -194,7 +305,9 @@ app/src/androidTest/java
 Con el emulador encendido, ejecutar:
 
 ```powershell
-.\gradlew.bat app:connectedDebugAndroidTest
+.\gradlew.bat app:connectedLocalDebugAndroidTest
+.\gradlew.bat app:connectedProdDebugAndroidTest
+.\gradlew.bat app:connectedRoboDebugAndroidTest
 ```
 
 Si hay problemas de Java, usar primero:
@@ -206,7 +319,7 @@ $env:Path="$env:JAVA_HOME\bin;$env:Path"
 
 ---
 
-## 9. Problemas comunes
+## 10. Problemas comunes
 
 ### Error: `nest is not recognized`
 
@@ -259,16 +372,25 @@ Dentro de `<application>`:
 android:usesCleartextTraffic="true"
 ```
 
+### Ejecuté el flavor incorrecto
+
+Si no aparecen datos esperados, verifica la variante activa:
+
+- `local`: requiere backend local arriba
+- `prod`: consulta backend productivo
+- `robo`: usa datos fake (sin backend)
+
 ---
 
-## 10. Flujo recomendado de ejecución
+## 11. Flujo recomendado de ejecución
 
 1. Levantar PostgreSQL.
 2. Ejecutar backend NestJS.
 3. Verificar endpoint en Postman.
 4. Encender emulador Android.
-5. Ejecutar app Android.
-6. Probar pruebas unitarias o Espresso si aplica.
+5. Elegir flavor (`local`, `prod` o `robo`).
+6. Ejecutar app Android con la variante elegida.
+7. Probar pruebas unitarias o Espresso si aplica.
 
 ```bash
 docker start postgres-vinyls
@@ -279,7 +401,13 @@ npm run start:dev
 Luego en Android:
 
 ```powershell
-.\gradlew.bat installDebug
+.\gradlew.bat app:installLocalDebug
+```
+
+Para Robo Test / Firebase Test Lab:
+
+```powershell
+.\gradlew.bat app:assembleRoboDebug
 ```
 
 ---

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,39 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
+
+     flavorDimensions += "environment"
+
+    productFlavors {
+        create("local") {
+            dimension = "environment"
+            applicationIdSuffix = ".local"
+            versionNameSuffix = "-local"
+
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:3000/\"")
+            buildConfigField("Boolean", "USE_FAKE_DATA", "false")
+        }
+
+        create("prod") {
+            dimension = "environment"
+            versionNameSuffix = "-prod"
+
+            buildConfigField("String", "BASE_URL", "\"https://backvynils-production-5c50.up.railway.app/\"")
+            buildConfigField("Boolean", "USE_FAKE_DATA", "false")
+        }
+
+        create("robo") {
+            dimension = "environment"
+            applicationIdSuffix = ".robo"
+            versionNameSuffix = "-robo"
+
+            buildConfigField("String", "BASE_URL", "\"https://unused-for-robo.local/\"")
+            buildConfigField("Boolean", "USE_FAKE_DATA", "true")
+        }
+    }
+
     
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.14"

--- a/app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeAlbumRepository.kt
+++ b/app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeAlbumRepository.kt
@@ -1,0 +1,74 @@
+package com.tsdc.vinilos.data.repositories.fake
+
+import com.tsdc.vinilos.domain.models.Album
+import com.tsdc.vinilos.domain.models.NewAlbum
+import com.tsdc.vinilos.domain.models.Track
+import com.tsdc.vinilos.domain.repositories.AlbumRepository
+
+class FakeAlbumRepository : AlbumRepository {
+
+    private val albums = mutableListOf(
+        Album(
+            id = 1,
+            name = "Buscando America",
+            cover = "https://picsum.photos/seed/album1/400/400",
+            releaseDate = "1984-08-01T00:00:00.000Z",
+            description = "Album de prueba para ejecucion en Robo Test.",
+            genre = "Salsa",
+            recordLabel = "EMI"
+        ),
+        Album(
+            id = 2,
+            name = "Poeta del Pueblo",
+            cover = "https://picsum.photos/seed/album2/400/400",
+            releaseDate = "1981-05-03T00:00:00.000Z",
+            description = "Datos mock para validar navegacion sin backend.",
+            genre = "Salsa",
+            recordLabel = "Fania"
+        )
+    )
+
+    private val tracksByAlbumId = mutableMapOf(
+        1 to mutableListOf(
+            Track(1, "Hijo de la Luna", "04:10"),
+            Track(2, "Lluvia", "03:45")
+        ),
+        2 to mutableListOf(
+            Track(3, "Volver", "03:58")
+        )
+    )
+
+    override suspend fun getAlbums(): List<Album> = albums.toList()
+
+    override suspend fun getAlbumById(id: Int): Album? = albums.firstOrNull { it.id == id }
+
+    override suspend fun createAlbum(newAlbum: NewAlbum): Album {
+        val nextId = (albums.maxOfOrNull { it.id } ?: 0) + 1
+        val created = Album(
+            id = nextId,
+            name = newAlbum.name,
+            cover = newAlbum.cover,
+            releaseDate = newAlbum.releaseDateIso,
+            description = newAlbum.description,
+            genre = newAlbum.genre,
+            recordLabel = newAlbum.recordLabel
+        )
+        albums.add(created)
+        tracksByAlbumId[nextId] = mutableListOf()
+        return created
+    }
+
+    override suspend fun getAlbumTracks(albumId: Int): List<Track> =
+        tracksByAlbumId[albumId]?.toList() ?: emptyList()
+
+    override suspend fun addTrackToAlbum(albumId: Int, name: String, duration: String): Track {
+        if (albums.none { it.id == albumId }) {
+            throw NoSuchElementException("Album with id $albumId was not found")
+        }
+        val nextTrackId = (tracksByAlbumId.values.flatten().maxOfOrNull { it.id } ?: 0) + 1
+        val newTrack = Track(id = nextTrackId, name = name, duration = duration)
+        val albumTracks = tracksByAlbumId.getOrPut(albumId) { mutableListOf() }
+        albumTracks.add(newTrack)
+        return newTrack
+    }
+}

--- a/app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeArtistRepository.kt
+++ b/app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeArtistRepository.kt
@@ -1,0 +1,43 @@
+package com.tsdc.vinilos.data.repositories.fake
+
+import com.tsdc.vinilos.domain.models.Artist
+import com.tsdc.vinilos.domain.repositories.ArtistRepository
+import java.util.Date
+
+class FakeArtistRepository : ArtistRepository {
+
+    private val artists = listOf(
+        Artist(
+            id = 1,
+            name = "Hector Lavoe",
+            image = "https://picsum.photos/seed/artist1/400/400",
+            description = "Artista mock para pruebas Robo.",
+            birthDate = Date(315532800000L)
+        ),
+        Artist(
+            id = 2,
+            name = "Celia Cruz",
+            image = "https://picsum.photos/seed/artist2/400/400",
+            description = "Datos simulados para navegacion y detalle.",
+            birthDate = Date(-781920000000L)
+        )
+    )
+
+    private val favoriteIds = mutableSetOf<Int>()
+
+    override suspend fun getArtists(): List<Artist> = artists
+
+    override suspend fun getArtistById(id: Int): Artist =
+        artists.firstOrNull { it.id == id }
+            ?: throw NoSuchElementException("Artist with id $id was not found")
+
+    override suspend fun isFavorite(artistId: Int): Boolean = artistId in favoriteIds
+
+    override suspend fun toggleFavorite(artistId: Int) {
+        if (artistId in favoriteIds) {
+            favoriteIds.remove(artistId)
+        } else {
+            favoriteIds.add(artistId)
+        }
+    }
+}

--- a/app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeCollectorRepository.kt
+++ b/app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeCollectorRepository.kt
@@ -1,0 +1,30 @@
+package com.tsdc.vinilos.data.repositories.fake
+
+import com.tsdc.vinilos.domain.models.Collector
+import com.tsdc.vinilos.domain.repositories.CollectorRepository
+
+class FakeCollectorRepository : CollectorRepository {
+
+    private val collectors = listOf(
+        Collector(
+            id = 1,
+            name = "Collector Demo",
+            telephone = "+57 300 000 0001",
+            email = "collector1@example.com",
+            albumCount = 2
+        ),
+        Collector(
+            id = 2,
+            name = "Collector QA",
+            telephone = "+57 300 000 0002",
+            email = "collector2@example.com",
+            albumCount = 1
+        )
+    )
+
+    override suspend fun getCollectors(): List<Collector> = collectors
+
+    override suspend fun getCollectorById(id: Int): Collector =
+        collectors.firstOrNull { it.id == id }
+            ?: throw NoSuchElementException("Collector with id $id was not found")
+}

--- a/app/src/main/java/com/tsdc/vinilos/di/AppModule.kt
+++ b/app/src/main/java/com/tsdc/vinilos/di/AppModule.kt
@@ -2,11 +2,15 @@ package com.tsdc.vinilos.di
 
 import android.content.Context
 import com.tsdc.vinilos.data.local.AppDatabase
+import com.tsdc.vinilos.BuildConfig
 import com.tsdc.vinilos.data.remote.network.ServiceAdapter
 import com.tsdc.vinilos.data.remote.network.VinilosApiService
 import com.tsdc.vinilos.data.repositories.ArtistRepository as ArtistRepositoryImpl
 import com.tsdc.vinilos.data.repositories.AlbumRepository as AlbumRepositoryImpl
 import com.tsdc.vinilos.data.repositories.CollectorRepository as CollectorRepositoryImpl
+import com.tsdc.vinilos.data.repositories.fake.FakeAlbumRepository
+import com.tsdc.vinilos.data.repositories.fake.FakeArtistRepository
+import com.tsdc.vinilos.data.repositories.fake.FakeCollectorRepository
 import com.tsdc.vinilos.domain.repositories.AlbumRepository
 import com.tsdc.vinilos.domain.repositories.ArtistRepository
 import com.tsdc.vinilos.domain.repositories.CollectorRepository
@@ -21,12 +25,11 @@ import com.tsdc.vinilos.domain.usecases.GetCollectorByIdUseCase
 import com.tsdc.vinilos.domain.usecases.GetCollectorsUseCase
 import com.tsdc.vinilos.domain.usecases.IsFavoriteArtistUseCase
 import com.tsdc.vinilos.domain.usecases.ToggleFavoriteArtistUseCase
+import com.tsdc.vinilos.ui.viewmodels.AlbumTracksViewModelFactory
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object AppModule {
-
-    private const val BASE_URL = "https://backvynils-production-5c50.up.railway.app/"
 
     private lateinit var appContext: Context
 
@@ -36,7 +39,7 @@ object AppModule {
 
     private val retrofit: Retrofit by lazy {
         Retrofit.Builder()
-            .baseUrl(BASE_URL)
+            .baseUrl(BuildConfig.BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
@@ -54,7 +57,11 @@ object AppModule {
     }
 
     val albumRepository: AlbumRepository by lazy {
-        AlbumRepositoryImpl(serviceAdapter, database.albumDao())
+        if (BuildConfig.USE_FAKE_DATA) {
+            FakeAlbumRepository()
+        } else {
+            AlbumRepositoryImpl(serviceAdapter, database.albumDao())
+        }
     }
 
     val getAlbumsUseCase: GetAlbumsUseCase by lazy {
@@ -77,8 +84,8 @@ object AppModule {
         AddTrackToAlbumUseCase(albumRepository)
     }
 
-    val albumTracksViewModelFactory: com.tsdc.vinilos.ui.viewmodels.AlbumTracksViewModelFactory by lazy {
-        com.tsdc.vinilos.ui.viewmodels.AlbumTracksViewModelFactory(
+    val albumTracksViewModelFactory: AlbumTracksViewModelFactory by lazy {
+        AlbumTracksViewModelFactory(
             getAlbumTracksUseCase,
             addTrackToAlbumUseCase,
             getAlbumByIdUseCase
@@ -86,7 +93,11 @@ object AppModule {
     }
 
     val artistRepository: ArtistRepository by lazy {
-        ArtistRepositoryImpl(serviceAdapter, database.favoriteArtistDao(), database.artistDao())
+        if (BuildConfig.USE_FAKE_DATA) {
+            FakeArtistRepository()
+        } else {
+            ArtistRepositoryImpl(serviceAdapter, database.favoriteArtistDao(), database.artistDao())
+        }
     }
 
     val getArtistsUseCase: GetArtistsUseCase by lazy {
@@ -106,7 +117,11 @@ object AppModule {
     }
 
     val collectorRepository: CollectorRepository by lazy {
-        CollectorRepositoryImpl(serviceAdapter, database.collectorDao())
+        if (BuildConfig.USE_FAKE_DATA) {
+            FakeCollectorRepository()
+        } else {
+            CollectorRepositoryImpl(serviceAdapter, database.collectorDao())
+        }
     }
 
     val getCollectorsUseCase: GetCollectorsUseCase by lazy {


### PR DESCRIPTION
El cambio principal fue convertir la app Android para que pueda compilarse en **tres flavors**: `local`, `prod` y `robo`. Además, se agregaron **repositorios fake** para álbumes, artistas y coleccionistas, y se actualizó la inyección de dependencias para usar datos reales o simulados según la variante compilada.

## Resumen de cambios

| Área | Cambio |
|---|---|
| Configuración Android | Se habilitó `buildConfig` y se definieron flavors `local`, `prod` y `robo` en `app/build.gradle.kts`. |
| URLs / entorno | La app ya no usa una `BASE_URL` fija en código; ahora depende de `BuildConfig.BASE_URL` según el flavor. |
| Datos fake | Se crearon `FakeAlbumRepository`, `FakeArtistRepository` y `FakeCollectorRepository`. |
| Inyección de dependencias | `AppModule` ahora decide si usa repositorios reales o fake con `BuildConfig.USE_FAKE_DATA`. |
| Documentación | El `README.md` se amplió bastante para explicar JDK, flavors, variantes, instalación y ejecución de tests. |

## Cambios más importantes

### 1. Nuevos product flavors
En `app/build.gradle.kts` se agregaron estos flavors:

- **`local`**
  - usa `http://10.0.2.2:3000/`
  - `USE_FAKE_DATA = false`
- **`prod`**
  - usa el backend productivo
  - `USE_FAKE_DATA = false`
- **`robo`**
  - usa una URL dummy
  - `USE_FAKE_DATA = true`

Esto permite compilar variantes como:

- `localDebug`
- `prodDebug`
- `roboDebug`

### 2. Soporte para pruebas sin backend
Se añadieron tres repositorios fake:

- `FakeAlbumRepository`
- `FakeArtistRepository`
- `FakeCollectorRepository`

Estos devuelven datos en memoria para poder:

- navegar la app,
- listar entidades,
- ver detalles,
- crear álbumes,
- agregar tracks,
- probar favoritos,

sin depender de servicios remotos.

### 3. Cambio en AppModule
En `AppModule.kt`:

- se eliminó la constante fija `BASE_URL`,
- Retrofit ahora usa `BuildConfig.BASE_URL`,
- y los repositorios se resuelven así:
  - si `USE_FAKE_DATA` es `true`, usa repositorios fake,
  - si no, usa los repositorios reales.

Este es el cambio estructural más importante del PR.

### 4. README más completo
El `README.md` fue actualizado para documentar:

- cómo configurar Java/Gradle correctamente,
- qué flavors existen y para qué sirve cada uno,
- cómo compilar cada variante,
- cómo instalar `local`, `prod` o `robo`,
- cómo correr pruebas unitarias e instrumentadas por flavor,
- y cuál APK usar para Robo Test.

## Impacto funcional
Con este PR, el equipo puede:

- seguir usando backend local,
- usar backend productivo,
- o correr la app en modo fake para automatización/pruebas de reconocimiento,

lo cual reduce dependencia del backend y hace más estable la ejecución en entornos de testing.

## Riesgo estimado
**Riesgo medio**:
- Es un cambio relativamente transversal porque toca configuración de build e inyección de dependencias.
- Pero está bien encapsulado: el comportamiento depende de `BuildConfig`, sin reescribir la lógica principal de pantallas.

## Archivos cambiados
Según la comparación, se modificaron/agregaron estos archivos principales:

- `README.md`
- `app/build.gradle.kts`
- `app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeAlbumRepository.kt`
- `app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeArtistRepository.kt`
- `app/src/main/java/com/tsdc/vinilos/data/repositories/fake/FakeCollectorRepository.kt`
- `app/src/main/java/com/tsdc/vinilos/di/AppModule.kt`
